### PR TITLE
add analogies dataset and new embeddings

### DIFF
--- a/hy/index.md
+++ b/hy/index.md
@@ -27,6 +27,8 @@ fastText has trained embeddings for the top few hundred languages, including Arm
 and 
 [Common Crawl](https://github.com/facebookresearch/fastText/blob/master/docs/crawl-vectors.md).
 
+[Word Analogy Task](https://github.com/ispras-texterra/word-embeddings-eval-hy/blob/master/word_analogy_task_hy.txt) along with GloVe, fastText, SkipGram, CBOW [embeddings](https://github.com/ispras-texterra/word-embeddings-eval-hy/blob/master/README.md) pre-trained on Wikipedia + news articles + blog posts.
+
 ### Syntax parsing
 
 https://github.com/UniversalDependencies/UD_Armenian-ArmTDP


### PR DESCRIPTION
Adding a link to an adaptation of Google's word analogy task (15646 analogy questions) and pre-trained word embeddings:

--200-dimensional GloVe\
--300-dimensional CBOW and SkipGram\
--200-dimensional fastText (.text, .bin).

The training data (90.5mln tokens) included:

--Wikipedia\
--fiction texts taken from the open part of the EANC corpus\
--HC Corpora containing blogs and news articles collected by Hans Christensen in 2011\
--digitized and reviewed part of Armenian soviet encyclopedia from Wikisource\
--news articles.
